### PR TITLE
fix decode_ssr when args contain space.

### DIFF
--- a/ssr-decode
+++ b/ssr-decode
@@ -44,7 +44,7 @@ decode_ssr() {
 	EOF
 
 	while IFS='=' read -r key value; do
-		[ -n "$value" ] && eval "$key=$(decode_base64 "$value")"
+		[ -n "$value" ] && eval "$key=\"$(decode_base64 "$value")\""
 	done <<- EOF
 		$(echo "${1#*/?}" | tr '&' '\n')
 	EOF


### PR DESCRIPTION
check it out.
when $value is a value like 'I have space chars.'
this eval fails.